### PR TITLE
Hide the "Show done tasks" checkbox if no done tasks

### DIFF
--- a/components/time/public/app/time/TimeCtrl.js
+++ b/components/time/public/app/time/TimeCtrl.js
@@ -89,6 +89,7 @@ angular.module('flokTimeModule').controller('TimeCtrl', [
          */
         $scope.deleteCompleted = function() {
             taskService.deleteCompleted();
+            $scope.showAll = false;
         };
 
         /**

--- a/components/time/public/app/time/time.tpl.html
+++ b/components/time/public/app/time/time.tpl.html
@@ -18,7 +18,7 @@
                             {{ 'flok.time.action.start'| translate }}
                         </button>
                         <div class="checkbox pull-right">
-                            <label>
+                            <label ng-show="completedCount > 0">
                                 <input type="checkbox" ng-model="showAll">{{ 'flok.time.filter.completed'| translate }}
                             </label>
                         </div>
@@ -126,7 +126,7 @@
                         {{totalTimeUncompleted + totalTimeCompleted | duration}} ({{totalTimeUncompleted + totalTimeCompleted | decimalDuration}})
                     </div>
                     <div class="grid-33 tablet-grid-33 mobile-grid-100">
-                        <button class="btn btn-warning" ng-show="showAll"
+                        <button class="btn btn-warning" ng-show="showAll && completedCount > 0"
                          ng-click="deleteCompleted() | track:'clear completed':$event">
                             <icon type="trash"></icon>
                             {{ 'flok.time.action.delete_completed'| translate }} ({{completedCount}})


### PR DESCRIPTION
If there are no completed tasks, the "Show done tasks" checkbox is hidden as well as the "Delete done tasks" button.

When deleting completed tasks, the "Show done tasks" checkbox is automatically unchecked.

@toebu Can you please review?